### PR TITLE
Retry SLES re-register script on error

### DIFF
--- a/sles-reregister-cloud-instances/playbook.yaml
+++ b/sles-reregister-cloud-instances/playbook.yaml
@@ -14,4 +14,8 @@
         /usr/sbin/registercloudguest --force-new
       args:
         warn: false
+      retries: 5
+      delay: 10
+      register: result
+      until: result.rc == 0
       when: ansible_distribution == 'SLES'


### PR DESCRIPTION
If this playbook is run immediately after provisioning hosts then it may
run into the race condition that causes registration to fail in the
first place.